### PR TITLE
feat(api): 럭키 드로우 시작 api

### DIFF
--- a/webinar-api/controllers/luckdraw.controller.js
+++ b/webinar-api/controllers/luckdraw.controller.js
@@ -1,0 +1,96 @@
+const { fn, Op } = require('sequelize');
+const Joi = require('joi');
+
+const { user } = require('../models');
+
+exports.startLuckdraw = async (req, res) => {
+  try {
+    const param = Joi.object({
+      event: Joi.number().integer().min(1).max(3)
+    })
+    if (param.validate(req.body).error) {
+      return res.status(400).send({
+        msg: '유효하지 않은 이벤트 번호입니다.',
+        msgId: 400
+      });
+    }
+
+    const { event } = req.body;
+    const targetSchool = new Set(['대덕소프트웨어마이스터고등학교', '광주소프트웨어마이스터고등학교', '대구소프트웨어마이스터고등학교']);
+    const schoolWinners = {
+      '대덕소프트웨어마이스터고등학교': 0,
+      '광주소프트웨어마이스터고등학교': 0,
+      '대구소프트웨어마이스터고등학교': 0 
+    }
+    const eventLimit = {
+      1: 2,
+      2: 1,
+      3: 1
+    }
+
+    const WinnerList = await user.findAll({
+      where: {
+        lucky_flag: { 
+          [Op.eq]: event
+        }
+      }
+    })
+  
+    WinnerList.forEach(userInfo => {
+      schoolWinners[userInfo.dataValues.school_name]++;
+    })
+    targetSchool.forEach(schoolName => {
+      if(schoolWinners[schoolName] >= eventLimit[event]) {
+        targetSchool.delete(schoolName)
+        if(event === 3) targetSchool.clear();
+      }
+    })
+  
+    if(targetSchool.size) {
+      const luckyList = await user.findAll({
+        order: fn('RAND'),
+        where: {
+          [Op.and]: [
+            {
+              school_name: {
+                [Op.or]: [...targetSchool]
+              }
+            },
+            {
+              lucky_flag: { 
+                [Op.eq]: 0
+              }
+            }
+          ]
+        },
+        limit: 1
+      })
+    
+      if(luckyList) {
+        await user.update({
+          lucky_flag: event
+        }, {
+          where: {
+            id: luckyList[0].dataValues.id
+          }
+        })
+        return res.status(200).send({
+          msg: '성공적으로 당첨자를 선정하였습니다.',
+          msgId: 200
+        })
+      }    
+    }
+    else {
+      return res.status(400).send({
+        msg: '해당 이벤트 상품의 잔량이 모두 소진되었습니다.',
+        msgId: 400
+      })
+    }
+  }
+  catch(error) {
+    res.status(500).send({
+      msg: "서버에서 오류가 발생하였습니다.",
+      msgId: 500
+    })
+  }
+}

--- a/webinar-api/routes/auth/index.js
+++ b/webinar-api/routes/auth/index.js
@@ -4,6 +4,8 @@ const { login, adminLogin } = require('../../controllers/login.controller');
 const { inputTimetable } = require('../../controllers/timetable.controller');
 const { newWebinar } = require("../../controllers/webinar.controller");
 
+const luckdraw = require("./luckdraw");
+
 const { adminAuth } = require('../../middlewares/auth.middle');
 
 const router = Router();
@@ -244,5 +246,7 @@ router.post('/webinar', adminAuth, newWebinar);
  *            description: "서버 에러"
  */
 router.post('/timetable', adminAuth, inputTimetable);
+
+router.use('/luckdraw', adminAuth, luckdraw);
 
 module.exports = router;

--- a/webinar-api/routes/auth/luckdraw/index.js
+++ b/webinar-api/routes/auth/luckdraw/index.js
@@ -1,0 +1,65 @@
+const { startLuckdraw } = require('../../../controllers/luckdraw.controller');
+
+const router = require('express').Router();
+
+/**
+ * @swagger
+ * definitions:
+ *   luckdraw_start_request:
+ *     type: object
+ *     properties:
+ *       event: 
+ *         type: integer
+ *         description: 이벤트 타입
+ *   luckdraw_start_response:
+ *     type: object
+ *     properties:
+ *       msg: 
+ *         type: string
+ *         description: 처리 메시지
+ *       msgId: 
+ *         type: integer
+ *         description: 처리 id
+ */
+
+/**
+ * @swagger
+ *  paths:
+ *    /auth/luckdraw/start:
+ *      post:
+ *        tags:
+ *        - "Luckdraw"
+ *        summary: "럭키 드로우 시작"
+ *        description: "럭키 드로우를 시작합니다"
+ *        produces:
+ *        - "application/json"
+ *        parameters:
+ *        - $ref: "#/definitions/x-access-token"
+ *        - in: "body"
+ *          name: "body"
+ *          description: "럭키 드로우를 시작하기 위한 정보를 받습니다."
+ *          required: true
+ *          schema:
+ *            $ref: "#/definitions/luckdraw_start_request" 
+ *        responses:
+ *          200:
+ *            description: "당첨자 선정 성공"
+ *            schema:
+ *              $ref: "#/definitions/luckdraw_start_response"
+ *          400:
+ *            description: "해당 이벤트 상품 소진"
+ *            schema:
+ *              $ref: "#/definitions/luckdraw_start_response"
+ *          401:
+ *            description: "인증 에러"
+ *            schema:
+ *              $ref: "#/definitions/luckdraw_start_response"
+ *          500:
+ *            description: "서버 에러"
+ *            schema:
+ *              $ref: "#/definitions/luckdraw_start_response"
+ */
+
+router.post('/start', startLuckdraw);
+
+module.exports = router;

--- a/webinar-api/routes/auth/luckdraw/index.js
+++ b/webinar-api/routes/auth/luckdraw/index.js
@@ -10,7 +10,7 @@ const router = require('express').Router();
  *     properties:
  *       event: 
  *         type: integer
- *         description: 이벤트 타입
+ *         description: 1 일반 경품 분배, 2 좋은 경품 분배, 3 학교 통합 랜덤 좋은 경품
  *   luckdraw_start_response:
  *     type: object
  *     properties:


### PR DESCRIPTION
# 구현사항
럭키 드로우 시작 API

## 같이 고민하면 좋을점
참고 사항에 나와있는 것 처럼 10개의 상품에서 6개는 학교별로 2개씩 배분, 3개는 학교별로 1개씩 배분, 나머지 1개는 학교 상관 없이 1개를 배분하는 것으로 만들었습니다.
실제로 사용될 때 참고사항과 상품의 개수와 분배 방식이 다르다면 그에 맞게 유동적으로 상품을 배분할 수 있는 로직을 구현하는 것이 좋을까요?

close #12 